### PR TITLE
Add Client.Scope

### DIFF
--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -211,6 +211,10 @@ func getContextAndTags(name string, tags []string) (string, string) {
 
 func (a *aggregator) count(name string, value int64, tags []string) error {
 	context := getContext(name, tags)
+	return a.countContext(context, name, value, tags)
+}
+
+func (a *aggregator) countContext(context string, name string, value int64, tags []string) error {
 	a.countsM.RLock()
 	if count, found := a.counts[context]; found {
 		count.sample(value)
@@ -234,6 +238,10 @@ func (a *aggregator) count(name string, value int64, tags []string) error {
 
 func (a *aggregator) gauge(name string, value float64, tags []string) error {
 	context := getContext(name, tags)
+	return a.gaugeContext(context, name, value, tags)
+}
+
+func (a *aggregator) gaugeContext(context, name string, value float64, tags []string) error {
 	a.gaugesM.RLock()
 	if gauge, found := a.gauges[context]; found {
 		gauge.sample(value)
@@ -258,6 +266,10 @@ func (a *aggregator) gauge(name string, value float64, tags []string) error {
 
 func (a *aggregator) set(name string, value string, tags []string) error {
 	context := getContext(name, tags)
+	return a.setContext(context, name, value, tags)
+}
+
+func (a *aggregator) setContext(context string, name string, value string, tags []string) error {
 	a.setsM.RLock()
 	if set, found := a.sets[context]; found {
 		set.sample(value)

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -678,6 +678,25 @@ func (c *Client) sendToAggregator(mType metricType, name string, value float64, 
 	return f(name, value, tags, rate)
 }
 
+// Scope embeds name and tags for a metric.
+type Scope struct {
+	context string
+	name    string
+	tags    []string
+	c       *Client
+}
+
+// Scope returns a cached version of name and tags.
+// You can use it to avoid extra allocations when sending the same metric multiple times.
+func (c *Client) Scope(name string, tags []string) *Scope {
+	return &Scope{
+		context: getContext(name, tags),
+		name:    name,
+		tags:    tags,
+		c:       c,
+	}
+}
+
 // Gauge measures the value of a metric at a particular time.
 func (c *Client) Gauge(name string, value float64, tags []string, rate float64) error {
 	if c == nil {
@@ -688,6 +707,18 @@ func (c *Client) Gauge(name string, value float64, tags []string, rate float64) 
 		return c.agg.gauge(name, value, tags)
 	}
 	return c.send(metric{metricType: gauge, name: name, fvalue: value, tags: tags, rate: rate, globalTags: c.tags, namespace: c.namespace})
+}
+
+// Gauge measures the value of a metric at a particular time.
+func (s *Scope) Gauge(value float64, rate float64) error {
+	if s == nil || s.c == nil {
+		return ErrNoClient
+	}
+	atomic.AddUint64(&s.c.telemetry.totalMetricsGauge, 1)
+	if s.c.agg != nil {
+		return s.c.agg.gaugeContext(s.context, s.name, value, s.tags)
+	}
+	return s.c.send(metric{metricType: gauge, name: s.name, fvalue: value, tags: s.tags, rate: rate, globalTags: s.c.tags, namespace: s.c.namespace})
 }
 
 // GaugeWithTimestamp measures the value of a metric at a given time.
@@ -719,6 +750,18 @@ func (c *Client) Count(name string, value int64, tags []string, rate float64) er
 		return c.agg.count(name, value, tags)
 	}
 	return c.send(metric{metricType: count, name: name, ivalue: value, tags: tags, rate: rate, globalTags: c.tags, namespace: c.namespace})
+}
+
+// Count tracks how many times something happened per second.
+func (s *Scope) Count(value int64, rate float64) error {
+	if s == nil || s.c == nil {
+		return ErrNoClient
+	}
+	atomic.AddUint64(&s.c.telemetry.totalMetricsCount, 1)
+	if s.c.agg != nil {
+		return s.c.agg.countContext(s.context, s.name, value, s.tags)
+	}
+	return s.c.send(metric{metricType: count, name: s.name, ivalue: value, tags: s.tags, rate: rate, globalTags: s.c.tags, namespace: s.c.namespace})
 }
 
 // CountWithTimestamp tracks how many times something happened at the given second.
@@ -769,9 +812,19 @@ func (c *Client) Decr(name string, tags []string, rate float64) error {
 	return c.Count(name, -1, tags, rate)
 }
 
+// Decr is just Count of -1
+func (s *Scope) Decr(rate float64) error {
+	return s.Count(-1, rate)
+}
+
 // Incr is just Count of 1
 func (c *Client) Incr(name string, tags []string, rate float64) error {
 	return c.Count(name, 1, tags, rate)
+}
+
+// Incr is just Count of 1
+func (s *Scope) Incr(rate float64) error {
+	return s.Count(1, rate)
 }
 
 // Set counts the number of unique elements in a group.
@@ -784,6 +837,18 @@ func (c *Client) Set(name string, value string, tags []string, rate float64) err
 		return c.agg.set(name, value, tags)
 	}
 	return c.send(metric{metricType: set, name: name, svalue: value, tags: tags, rate: rate, globalTags: c.tags, namespace: c.namespace})
+}
+
+// Set counts the number of unique elements in a group.
+func (s *Scope) Set(value string, rate float64) error {
+	if s == nil || s.c == nil {
+		return ErrNoClient
+	}
+	atomic.AddUint64(&s.c.telemetry.totalMetricsSet, 1)
+	if s.c.agg != nil {
+		return s.c.agg.setContext(s.context, s.name, value, s.tags)
+	}
+	return s.c.send(metric{metricType: set, name: s.name, svalue: value, tags: s.tags, rate: rate, globalTags: s.c.tags, namespace: s.c.namespace})
 }
 
 // Timing sends timing information, it is an alias for TimeInMilliseconds


### PR DESCRIPTION
Currently the Client allocates a new context every time a counter/gauge/set is updated.

I use a small number of tags in my application multiple times, so I would like to cache the context to avoid an allocation.

This commit implements a new Scope structure that caches the context string and allows the application to update counters without an allocation.

I run the following benchmarks two times with -count=5:

```go
func BenchmarkStatsdCounter(b *testing.B) {
	s, err := statsd.New("localhost:8125", statsd.WithNamespace("my_namespace"),
		statsd.WithClientSideAggregation(), statsd.WithExtendedClientSideAggregation())
	if err != nil {
		b.Fatal(err)
	}
	b.ReportAllocs()
	labels := []string{"label1:value1", "label2:value2"}
	b.ResetTimer()
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			s.Count("my_metric", 1, labels, 1)
		}
	})
}

func BenchmarkStatsdCounterScope(b *testing.B) {
	s, err := statsd.New("localhost:8125", statsd.WithNamespace("my_namespace"),
		statsd.WithClientSideAggregation(), statsd.WithExtendedClientSideAggregation())
	if err != nil {
		b.Fatal(err)
	}
	b.ReportAllocs()
	labels := []string{"label1:value1", "label2:value2"}
	mc := s.Scope("my_metric", labels)
	b.ResetTimer()
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			mc.Count(1, 1)
		}
	})
}
```

The benchstat results:

```
goos: linux
goarch: amd64
pkg: gitlab.skypicker.com/go/pkg/monitoring/metricsv2
cpu: 12th Gen Intel(R) Core(TM) i7-1260P
                      │  bench.txt   │
                      │    sec/op    │
StatsdCounter           56.25n ±  5%
StatsdCounter-2         90.99n ±  5%
StatsdCounter-4         101.2n ± 40%
StatsdCounter-8         139.9n ±  4%
StatsdCounter-16        123.6n ±  4%
StatsdCounterScope      30.40n ±  5%
StatsdCounterScope-2    107.2n ±  7%
StatsdCounterScope-4    104.5n ±  7%
StatsdCounterScope-8    126.7n ±  5%
StatsdCounterScope-16   96.54n ± 25%
geomean                 90.60n

                      │  bench.txt   │
                      │     B/op     │
StatsdCounter           48.00 ± 0%
StatsdCounter-2         48.00 ± 0%
StatsdCounter-4         48.00 ± 0%
StatsdCounter-8         48.00 ± 0%
StatsdCounter-16        48.00 ± 0%
StatsdCounterScope      0.000 ± 0%
StatsdCounterScope-2    0.000 ± 0%
StatsdCounterScope-4    0.000 ± 0%
StatsdCounterScope-8    0.000 ± 0%
StatsdCounterScope-16   0.000 ± 0%
geomean                            ¹
¹ summaries must be >0 to compute geomean

                      │  bench.txt   │
                      │  allocs/op   │
StatsdCounter           1.000 ± 0%
StatsdCounter-2         1.000 ± 0%
StatsdCounter-4         1.000 ± 0%
StatsdCounter-8         1.000 ± 0%
StatsdCounter-16        1.000 ± 0%
StatsdCounterScope      0.000 ± 0%
StatsdCounterScope-2    0.000 ± 0%
StatsdCounterScope-4    0.000 ± 0%
StatsdCounterScope-8    0.000 ± 0%
StatsdCounterScope-16   0.000 ± 0%
geomean                            ¹
¹ summaries must be >0 to compute geomean
```